### PR TITLE
feat: add Button component with styling and props for variant and dis…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
     "@fontsource-variable/onest": "^5.2.7",
     "astro": "^5.7.11",
     "astro-icon": "^1.1.5"
-  }
+  },
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,0 +1,45 @@
+---
+const { variant = "primary", disabled = false } = Astro.props;
+---
+
+<button class={`btn ${variant}`} disabled={disabled}>
+  <slot />
+</button>
+
+<style>
+  .btn {
+    border-radius: 0.25rem;
+    padding: 1rem 2.25rem;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+
+    &.primary {
+      color: #000000;
+      border: 1px solid #2dd4bf;
+      background-color: #2dd4bf;
+      transition:
+        color 0.3s,
+        background-color 0.3s,
+        border 0.3s,
+        outline 0.3s;
+
+      &:hover {
+        color: #ffffff;
+        background-color: #0d9483;
+        border: 1px solid #0d9483;
+      }
+
+      &:focus {
+        outline: 2px solid #0d9483;
+        outline-offset: 2px;
+      }
+    }
+
+    &:disabled {
+      background-color: #e5e7eb;
+      color: #9ca3af;
+      cursor: not-allowed;
+    }
+  }
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@contracts": ["src/contracts"]
+    }
+  }
 }


### PR DESCRIPTION

This pull request includes updates to the project dependencies and introduces a new reusable `Button` component with customizable styles and states. Below is a summary of the most important changes:

### Dependency Updates:
* Updated `package.json` to specify the use of `pnpm` as the package manager, locking it to version `10.5.2` with a specific integrity hash.

### Component Additions:
* Added a new `Button` component in `src/components/Button.astro`:
  * Accepts `variant` (default: "primary") and `disabled` (default: `false`) as props.
  * Includes styles for the primary variant, hover and focus states, and a disabled state.
  * Uses scoped CSS to ensure styles are encapsulated within the component.